### PR TITLE
More information about database changes

### DIFF
--- a/lib/screens/view_databse.dart
+++ b/lib/screens/view_databse.dart
@@ -87,6 +87,25 @@ class _DatabaseViewScreenState extends State<DatabaseViewScreen> {
     }
   }
 
+  TextStyle get _normalStyle => TextStyle();
+  TextStyle get _editStyle => TextStyle(
+    fontWeight: FontWeight.bold,
+  );
+  TextStyle get _deleteStyle => TextStyle(
+    color: Theme.of(context).colorScheme.error,
+    fontWeight: FontWeight.bold,
+  );
+
+  TextStyle _tableStyleFor(DatabaseItem dbItem) {
+    if (_markedForDeletion(dbItem)) {
+      return _deleteStyle;
+    }
+    if (_markedForEdit(dbItem)) {
+      return _editStyle;
+    }
+    return _normalStyle;
+  }
+
   /// Checks to see if there is a [DatabaseItem] with the same ID as [dbItem]
   /// that has been edited this session. If so, the newer version is returned;
   /// otherwise, the original item is returned.
@@ -240,7 +259,22 @@ class _DatabaseViewScreenState extends State<DatabaseViewScreen> {
                 padding: const EdgeInsets.fromLTRB(8, 4, 8, 10),
                 child: Row(
                   children: [
-                    Text('There are ${_retrievedItems!.length} items in the database.'),
+                    Text(
+                      "There are ${_retrievedItems!.length} items "
+                      "in the database.",
+                    ),
+                    Text(
+                      "${_itemsToEdit.length} "
+                      "${_itemsToEdit.length == 1 ? "is" : "are"} "
+                      "being edited.",
+                      style: _editStyle,
+                    ),
+                    Text(
+                      "${_itemsToDelete.length} "
+                      "${_itemsToDelete.length == 1 ? "is" : "are"} "
+                      "marked for deletion.",
+                      style: _deleteStyle,
+                    ),
                     const Spacer(),
                     ElevatedButton(
                       onPressed: _markOldEventsToDelete,
@@ -254,7 +288,13 @@ class _DatabaseViewScreenState extends State<DatabaseViewScreen> {
                           ? const Text("Upload in progress...")
                           : const Text("Apply changes"),
                     ),
-                  ],
+                  ].map((e) => e is Spacer
+                    ? e
+                    : Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: e
+                    ),
+                  ).toList(),
                 ),
               ),
             if (_retrievedItems == null)
@@ -285,15 +325,7 @@ class _DatabaseViewScreenState extends State<DatabaseViewScreen> {
                                   DateTime dt => DatabaseItem.formatDate(dt),
                                   dynamic otherType => otherType.toString(),
                                 },
-                                style: TextStyle(
-                                  color: _markedForDeletion(rowItem)
-                                    ? Theme.of(context).colorScheme.error
-                                    : null,
-                                  fontWeight: _markedForEdit(rowItem)
-                                          || _markedForDeletion(rowItem)
-                                    ? FontWeight.bold
-                                    : FontWeight.normal,
-                                ),
+                                style: _tableStyleFor(rowItem),
                                 overflow: TextOverflow.fade,
                               ),
                             ),

--- a/lib/screens/view_databse.dart
+++ b/lib/screens/view_databse.dart
@@ -4,6 +4,7 @@ import 'package:hendrix_today_uploader/firebase/database_item.dart';
 import 'package:hendrix_today_uploader/firebase/download.dart';
 import 'package:hendrix_today_uploader/firebase/upload.dart';
 import 'package:hendrix_today_uploader/firebase/upload_result.dart';
+import 'package:hendrix_today_uploader/widgets/confirm_upload.dart';
 import 'package:hendrix_today_uploader/widgets/edit_dialog.dart';
 import 'package:hendrix_today_uploader/widgets/table_scroller.dart';
 
@@ -101,6 +102,16 @@ class _DatabaseViewScreenState extends State<DatabaseViewScreen> {
 
   void _applyChanges() async {
     if (_dbUpdateInProgress) {
+      return;
+    }
+    final confirmChoice = await showDialog<bool>(
+      context: context,
+      builder: (context) => ConfirmUploadDialog(
+        editCount: _itemsToEdit.length,
+        deleteCount: _itemsToDelete.length,
+      ),
+    );
+    if (confirmChoice != true) {
       return;
     }
     if (mounted) {

--- a/lib/widgets/confirm_leave.dart
+++ b/lib/widgets/confirm_leave.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class ConfirmLeaveDialog extends StatelessWidget {
+  const ConfirmLeaveDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text("Discard Changes"),
+      content: const Text(
+        "Leaving the page will cause any changes not saved to the database to "
+        "be lost. Are you sure you want to leave?",
+      ),
+      actions: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8.0),
+          child: ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context, false);
+            },
+            child: const Text("No, stay here"),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8.0),
+          child: ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context, true);
+            },
+            child: const Text("Yes, discard changes and leave"),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/confirm_upload.dart
+++ b/lib/widgets/confirm_upload.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class ConfirmUploadDialog extends StatelessWidget {
+  const ConfirmUploadDialog({
+    super.key,
+    required this.editCount,
+    required this.deleteCount,
+  });
+  final int editCount;
+  final int deleteCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final String deleteStr = "$deleteCount event${deleteCount == 1 ? '' : 's'}";
+    final String editStr= "$editCount event${editCount == 1 ? '' : 's'}";
+    return AlertDialog(
+      title: const Text("Confirm Changes"),
+      content: Text(
+        "If you upload the current changes, $deleteStr will be deleted and "
+        "$editStr will be edited. Are you sure you want to continue?"
+      ),
+      actions: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8.0),
+          child: ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context, false);
+            },
+            child: const Text("No, go back"),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8.0),
+          child: ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context, true);
+            },
+            child: const Text("Yes, upload changes"),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
* Added text on the View Database screen that counts the current number of events being edited and deleted
* Added a confirmation dialog before uploading events to Firestore
* Added a confirmation dialog before leaving the page and losing unsaved changes

Closes #19